### PR TITLE
MLR-133: Added basic CORS support to the gateway service.

### DIFF
--- a/src/main/java/gov/usgs/wma/mlrgateway/config/WebMvcConfig.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package gov.usgs.wma.mlrgateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+public class WebMvcConfig {
+	
+	@Bean
+	public WebMvcConfigurer corsConfigurer() {
+		return new WebMvcConfigurerAdapter() {
+			@Override
+			public void addCorsMappings(CorsRegistry registry) {
+				registry.addMapping("/**");
+			}
+		};
+	}
+}

--- a/src/main/java/gov/usgs/wma/mlrgateway/config/WebSecurityConfig.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/config/WebSecurityConfig.java
@@ -18,6 +18,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
+			.cors().and()
 			.authorizeRequests()
 				.antMatchers("/workflows/**").permitAll()
 				.antMatchers("/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/v2/**").permitAll()


### PR DESCRIPTION
This is a very bare-bones enabling of CORS and will potentially require some changes when we switch to Keycloak-based auth.

I noticed that every POST request I submit cross-domain returns a 200 with the full login page source html as a string for the response, which is something that will need to be fixed before the UI is actually functional. I wasn't sure if it was worth the work of figuring out how to properly handle and perform the login page redirect at this point though since the switch to Keycloak will potentially change the way it needs to work.

EDIT: It looks like the issue I was having with the POST requests was because I was hitting an outdated URL. Updating the URL appears to have solved the issue.