### PR TITLE
MLR-219: Add proper support for Docker Secrets and OAuth2 client configuration to the Gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM openjdk:8-jdk-alpine
 RUN set -x & apk update && apk upgrade && apk add --no-cache curl
 ARG mlr_version
+
+ADD docker-entrypoint.sh entrypoint.sh
+RUN ["chmod", "+x", "entrypoint.sh"]
+
 RUN  curl -k -X GET "https://cida.usgs.gov/artifactory/mlr-maven-centralized/gov/usgs/wma/mlrgateway/$mlr_version/mlrgateway-$mlr_version.jar" > app.jar
+
 EXPOSE 8080
-ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar app.jar" ]
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ The default profile, which is run when either no profile is provided or the prof
 
 The localDev profile, which is run when the profile name "localDev" is provided, is setup to require no external database - Sessions are stored internally.
 
+## Spring Security Client Configuration
+This is a secured application that must connect to a running instance of the Water Auth Server in order to work. The following environment variables are used to configure the connection to the water auth server via OAuth2.
+
+- **oauthClientId** - The ID of the Client that has been configured in the Water Auth Server for this application.
+
+- **oauthClientSecret** - The secret associated with the Client that has been configured in the Water Auth Server for this application.
+
+- **oauthClientAccessTokenUri** - The OAuth2 Token URI that this application should connect to.
+
+- **oauthClientAuthorizationUri** -  The OAuth2 Authorization URI that this application should connect to.
+
+- **oauthResourceId** - The resource ID associated with the Client that has been configured in the Water Auth Server for this application.
+
+- **oauthResourceTokenKeyUri** - The OAuth2 Token Key URI that this application should connect to.
+
 ## Spring Security Client and Session Storage
 This service by default stores session data within a database rather than within the application itself. This allows for multiple running instances of this service to share session information, thereby making the service stateless. 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -x
+
+if [ $dbPassword ]; then
+    MYSQL_PASSWORD_VAL=$dbPassword
+elif [ $dbPassword_file ]; then
+    MYSQL_PASSWORD_VAL=`cat $dbPassword_file`
+fi
+
+if [ $oauthClientSecret ]; then
+    OAUTH_CLIENT_SECRET_VAL=$oauthClientSecret
+elif [ $oauthClientSecret_file ]; then
+    OAUTH_CLIENT_SECRET_VAL=`cat $oauthClientSecret_file`
+fi
+
+java -Djava.security.egd=file:/dev/./urandom -DdbPassword=$MYSQL_PASSWORD_VAL -DoauthClientSecret=$OAUTH_CLIENT_SECRET_VAL -jar app.jar
+
+exec $?

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,17 @@ logging:
   level:
     org:
       springframework: ${mlrgateway_springFrameworkLogLevel}
+
+security:
+  basic:
+    enabled: false
+  oauth2:
+    client:
+      clientId: ${oauthClientId}
+      clientSecret: ${oauthClientSecret}
+      accessTokenUri: ${oauthClientAccessTokenUri}
+      userAuthorizationUri: ${oauthClientAuthorizationUri}
+    resource:
+      id: ${oauthResourceId}
+      jwt:
+        keyUri: ${oauthResourceTokenKeyUri}


### PR DESCRIPTION
I made this PR to address the issues I saw with the Gateway in CHS. I haven't had a chance to update the deploy jobs and deploy config job yet but I can do that tomorrow.