### PR TITLE
Changes to support file uploads larger than the default 1MB and bette…

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -35,8 +35,8 @@
 					<div class="mlr-action" id="mlr-ddot">
 						<h3 id="ddot-header" class="mlr-action-header">Upload and Process a Ddot File</h3>
 						<form name="ddotForm" id="ddotForm" method="POST" enctype="multipart/form-data">
-							<label for="ddotFile">Select Ddot File to Upload</label>
-							<input id="ddotFile" type="file" name="ddotFile" class="uploadDdotFile">
+							<label for="file">Select Ddot File to Upload</label>
+							<input id="file" type="file" name="file" class="uploadDdotFile">
 							<input type="button" value="Validate" class="btn btn-xs btn-primary uploadDdotFile mlr-button-input" onclick="validateDdot()">&nbsp;
 							<input type="button" value="Validate and Update Records" class="btn btn-xs btn-primary uploadDdotFile mlr-button-input" onclick="uploadDdot()">
 						</form>
@@ -57,7 +57,8 @@
 					<div class="spinner-container">
 						<span id="mlr-loading-spinner"></span>
 					</div>
-					<p class="mlr-response-text"></p>
+					<p class="mlr-response-text" hidden="hidden"></p>
+					<a id="mlr-response-link" hidden="hidden" href="" target="_blank" download="mlr-results.json">Download the Full Step Report</a>
 				</div>
 			</div>
 		</div>

--- a/src/main/resources/static/ui.css
+++ b/src/main/resources/static/ui.css
@@ -57,6 +57,9 @@
 
 .mlr-response-text {
 	margin-left: 1px;
+	max-height: 640px;
+	word-wrap: break-word;
+	overflow-y: scroll;
 }
 
 #exportForm label {

--- a/src/main/resources/static/ui.js
+++ b/src/main/resources/static/ui.js
@@ -98,7 +98,8 @@ function postExport(responseHeader, success, error) {
 			error: error
 		});
 	} else {
-		stopLoading(responseHeader + " - Error", "Site export parameters incomplete.");
+		handleResponseTest("Site export parameters incomplete.");
+		stopLoading(responseHeader + " - Error");
 	}
 }
 

--- a/src/main/resources/static/ui.js
+++ b/src/main/resources/static/ui.js
@@ -1,48 +1,77 @@
+var reportUrl = null;
+var uploadRequest = false;
+
 function startLoading(headerText) {
 	$("#ddotForm :input").prop("disabled", true);
 	$("#exportForm :input").prop("disabled", true);
 	$('.mlr-response').show();
 	$('#mlr-loading-spinner').addClass('spinner');
 	$('.mlr-response-text').text("");
+	$('.mlr-response-text').hide();
+	$('#mlr-response-link').attr("href", "");
+	$('#mlr-response-link').hide();
 	$('.mlr-response-header').text(headerText);
 }
 
-function stopLoading(headerText, responseText) {
+function stopLoading(headerText) {
 	$("#ddotForm :input").prop("disabled", false);
 	$("#exportForm :input").prop("disabled", false);
 	$('.mlr-response').show();
 	$('#mlr-loading-spinner').removeClass('spinner');
 	$('.mlr-response-header').text(headerText);
-	$('.mlr-response-text').html(responseText);
+}
+
+function handleResponseJson(json) {
+	if(json.hasOwnProperty("steps")) {
+		reportUrl = URL.createObjectURL(new Blob([JSON.stringify(json, null, 4)], {type: "application/json"}));
+		$('.mlr-response-text').hide();
+		$('#mlr-response-link').show();
+		$('#mlr-response-link').attr("href", reportUrl);
+	} else {
+		reportUrl = null;
+		$('.mlr-response-text').html(formatJsonResponse(json));
+		$('.mlr-response-text').show();
+		$('#mlr-response-link').hide();
+	}
+}
+
+function handleResponseText(text) {
+	reportUrl = null;
+	$('.mlr-response-text').text(text);
+	$('.mlr-response-text').show();
+	$('#mlr-response-link').hide();
 }
 
 function generalSuccess (response) {
-	stopLoading($('.mlr-response-header').text() + " - Success", formatJsonResponse(response));
+	stopLoading($('.mlr-response-header').text() + " - Success", handleResponseJson(response));
 }
 
-function generalError (response) {
-	var responseText;
-	
+function generalError (response) {	
 	if(response.status > 0){
 		if(response.hasOwnProperty("responseJSON")){
-			responseText = formatJsonResponse(response.responseJSON);
+			handleResponseJson(response.responseJSON);
 		} else if(response.status == 401) {
 			// Got a 401 before a response map could be built, so warn of a potential expired session.
-			responseText = "It appears that your session may have expired or you are not logged in. Please refresh " + 
-				"the page and try again. If this issue persists please contact the support team.";
+			handleResponseText("It appears that your session may have expired or you are not logged in. Please refresh " + 
+				"the page and try again. If this issue persists please contact the support team.");			
 		} else {
 			try {
-				responseText = formatJsonResponse(JSON.parse(response.responseText));
+				handleResponseJson(JSON.parse(response.responseText));
 			} catch(error) {
-				responseText = "An unknown error occurred while trying to process your request (status code: " + response.status + "). " +
-				"If this issue persists please contact the support team with the status code listed above.";
+				handleResponseText("An unknown error occurred while trying to process your request (status code: " + response.status + "). " +
+				"If this issue persists please contact the support team with the status code listed above.");
 			}
 		}
 	} else {
-		responseText = "Connection Error with Gateway Service. If this issue persists please contact the support team.";
+		if(uploadRequest) {
+			handleResponseText("Connection Error with the Gateway Service. It's possible that the file you're trying to upload greatly" +
+			" exceeds the maximum file upload size allowed by the server. Please try a smaller file or contact the support team.");
+		} else {
+			handleResponseText("Connection Error with the Gateway Service. If this issue persists please contact the support team.");
+		}
 	}
 	
-	stopLoading($('.mlr-response-header').text() + " - Failure", responseText);
+	stopLoading($('.mlr-response-header').text() + " - Failure");
 }
 
 function postExport(responseHeader, success, error) {
@@ -51,11 +80,12 @@ function postExport(responseHeader, success, error) {
 		
 	if(agencyCode !== null && agencyCode.length > 0 && siteNumber !== null && siteNumber.length > 0) {
 		//Build URL
-		
 		var url = "legacy/location/" + agencyCode + "/" + siteNumber;
 
 		//Adjust UI
 		startLoading(responseHeader);
+
+		uploadRequest = false;
 
 		//Perform Export
 		$.ajax({
@@ -75,12 +105,13 @@ function postExport(responseHeader, success, error) {
 function postDdot(url, responseHeader, success, error) {
 	//Grab File to Upload
 	var documentData = new FormData($("#ddotForm")[0]);
-	documentData.append('file', $('input[type=file]')[0].files[0]);
 	
 	//Check selected file
 	if($('input[type=file]')[0].files.length > 0){
 		//Adjust UI
 		startLoading(responseHeader);
+
+		uploadRequest = true;
 
 		//Perform Upload
 		$.ajax({


### PR DESCRIPTION
…r handling of large JSON reports in the UI.

In addition to these changes some ENVs need to be overridden in the service config ENV files:

```
SERVER_TOMCAT_MAX_HTTP_POST_SIZE=25165824 (24MB)
SPRING_HTTP_MULTIPART_MAX_FILE_SIZE=10MB
SPRING_HTTP_MULTIPART_MAX_REQUEST_SIZE=20MB
```
`SERVER_TOMCAT_MAX_HTTP_POST_SIZE` needs to be larger than `SPRING_HTTP_MULTIPART_MAX_REQUEST_SIZE`.

If files are uploaded that are larger than `SPRING_HTTP_MULTIPART_MAX_REQUEST_SIZE` the server will reject the request outright which was the reason I added:

`"Connection Error with the Gateway Service. It's possible that the file you're trying to upload greatly exceeds the maximum file upload size allowed by the server. Please try a smaller file or contact the support team."`

to the UI when the response code is 0 and the request included uploading a DDot