### PR TITLE
Standardized feignclient method response types.

### DIFF
--- a/src/main/java/gov/usgs/wma/mlrgateway/client/DdotClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/DdotClient.java
@@ -1,6 +1,7 @@
 package gov.usgs.wma.mlrgateway.client;
 
 import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -15,6 +16,6 @@ public interface DdotClient {
 
 	@RequestMapping(method=RequestMethod.POST, value="ddots")
 	@Headers("Content-Type: multipart/form-data")
-	String ingestDdot(@RequestPart MultipartFile file);
+	ResponseEntity<String> ingestDdot(@RequestPart MultipartFile file);
 
 }

--- a/src/main/java/gov/usgs/wma/mlrgateway/service/DdotService.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/service/DdotService.java
@@ -46,7 +46,7 @@ public class DdotService {
 		TypeReference<List<Map<String, Object>>> mapType = new TypeReference<List<Map<String, Object>>>() {};
 		
 		try {
-			String ddotResponse = ddotClient.ingestDdot(file);
+			String ddotResponse = ddotClient.ingestDdot(file).getBody();
 			ddots = mapper.readValue(ddotResponse, mapType);
 		} catch (Exception e) {
 			int status = HttpStatus.SC_INTERNAL_SERVER_ERROR;
@@ -64,5 +64,4 @@ public class DdotService {
 		WorkflowController.addWorkflowStepReport(new StepReport(STEP_NAME, HttpStatus.SC_OK, true, SUCCESS_MESSAGE));
 		return ddots;
 	}
-
 }

--- a/src/test/java/gov/usgs/wma/mlrgateway/service/DdotServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/service/DdotServiceTest.java
@@ -22,6 +22,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.multipart.MultipartFile;
@@ -55,7 +56,7 @@ public class DdotServiceTest extends BaseSpringTest {
 	public void garbageFromDdot_thenReturnInternalServerError() throws Exception {
 
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
-		String ddotRtn = "not json";
+		ResponseEntity<String> ddotRtn = new ResponseEntity<> ("not json", HttpStatus.OK);
 		given(ddotClient.ingestDdot(any(MultipartFile.class))).willReturn(ddotRtn);
 		try {
 			service.parseDdot(file);
@@ -110,8 +111,8 @@ public class DdotServiceTest extends BaseSpringTest {
 	public void happyPath() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
 		ObjectMapper mapper = new ObjectMapper();
-		String ddotResponse = mapper.writeValueAsString(singleAdd());
-		given(ddotClient.ingestDdot(any(MultipartFile.class))).willReturn(ddotResponse);
+		ResponseEntity<String> ddotRtn = new ResponseEntity<> (mapper.writeValueAsString(singleAdd()), HttpStatus.OK);
+		given(ddotClient.ingestDdot(any(MultipartFile.class))).willReturn(ddotRtn);
 		List<Map<String, Object>> rtn = service.parseDdot(file);
 		GatewayReport gatewayReport = WorkflowController.getReport();
 		StepReport ddotStep = gatewayReport.getWorkflowSteps().stream()


### PR DESCRIPTION
Small bit of standardization within the Gateway which will hopefully help towards standardizing error parsing.

The other client classes return a ResponseEntity wrapper around the body, so I updated the DDot client to do the same.