### PR TITLE
don't show popup alert and run validate/update as usual for ddots with a

### DIFF
--- a/src/main/resources/static/ui.js
+++ b/src/main/resources/static/ui.js
@@ -160,6 +160,8 @@ function preVerification(response) {
 	var confirmProceed;
 	if (districtCodes.length > 1) {
 		confirmProceed = confirm(multipleDistrictCodeMsg);
+	} else {
+		confirmProceed = true;
 	}
 	if (confirmProceed) {
 		if (doUpdate){


### PR DESCRIPTION
single district code.