### PR TITLE
Upgraded to Spring Boot 2.x. Did not update to latest Spring Security…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,29 +10,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <additionalparam>-Xdoclint:none</additionalparam>
-        <springfox.version>2.7.0</springfox.version>
+        <springfox.version>2.8.0</springfox.version>
         <wma.artifactory.url>https://cida.usgs.gov/artifactory</wma.artifactory.url>
-        <spring.boot.version>1.5.8.RELEASE</spring.boot.version>
     </properties>
 
-    <distributionManagement>
-        <repository>
-            <id>release</id>
-            <name>cidasdpdasartip.cr.usgs.gov-releases</name>
-            <url>${wma.artifactory.url}/mlr-maven-releases</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>cidasdpdasartip.cr.usgs.gov-snapshots</name>
-            <url>${wma.artifactory.url}/mlr-maven-snapshots</url>
-        </snapshotRepository>
-    </distributionManagement> 
     <parent>
         <groupId>gov.usgs.water</groupId>
         <artifactId>code-quality</artifactId>
         <version>1.1.0</version>
     </parent>
-
     
     <repositories>
         <repository>
@@ -47,41 +33,75 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <scope>import</scope>
+                <version>2.2.5.RELEASE</version>
                 <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Dalston.SR4</version>
+                <version>Greenwich.SR5</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Security Upgrades -->
+            <!-- 3/16/2020 -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.64</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>9.0.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>9.0.30</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-hystrix-dashboard</artifactId>
+            <artifactId>spring-cloud-starter-netflix-hystrix-dashboard</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-zuul</artifactId>
+            <artifactId>spring-cloud-starter-netflix-zuul</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-feign</artifactId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.github.openfeign.form</groupId>
             <artifactId>feign-form-spring</artifactId>
@@ -91,24 +111,20 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>${springfox.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${springfox.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -118,15 +134,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.5</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
         </dependency>
 
         <!-- Web Jars -->
@@ -182,7 +189,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/gov/usgs/wma/mlrgateway/Application.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/Application.java
@@ -3,10 +3,10 @@ package gov.usgs.wma.mlrgateway;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
-import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableHystrixDashboard

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/DdotClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/DdotClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/FileExportClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/FileExportClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyCruClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyCruClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyTransformerClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyTransformerClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyValidatorClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/LegacyValidatorClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/gov/usgs/wma/mlrgateway/client/NotificationClient.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/client/NotificationClient.java
@@ -1,6 +1,6 @@
 package gov.usgs.wma.mlrgateway.client;
 
-import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;

--- a/src/main/java/gov/usgs/wma/mlrgateway/config/SwaggerConfig.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/config/SwaggerConfig.java
@@ -4,10 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import com.google.common.base.Predicates;
-
 import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.service.Tag;
+import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -16,16 +14,15 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 @Profile("swagger")
 public class SwaggerConfig {
-
+	/**
+	 * @return The Springfox framework primary interface.
+	 */
 	@Bean
-	public Docket gatewayApi() {
+	public Docket api() { 
 		return new Docket(DocumentationType.SWAGGER_2)
-				.tags(new Tag("Workflow", "Process D dot files"), new Tag("Export Workflow", "Generate Add Transaction File"))
-				.useDefaultResponseMessages(false)
 				.select()
-					.paths(Predicates.or(PathSelectors.ant("/workflows/**"), PathSelectors.ant("/info/**"), PathSelectors.ant("/health/**"), PathSelectors.ant("/legacy/**"), PathSelectors.ant("/util/**")))
-				.build()
-			;
+				.apis(RequestHandlerSelectors.any())
+				.paths(PathSelectors.any())
+				.build();
 	}
-
 }

--- a/src/main/java/gov/usgs/wma/mlrgateway/config/WebMvcConfig.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/config/WebMvcConfig.java
@@ -8,20 +8,15 @@ import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.resource.WebJarsResourceResolver;
 
 @Configuration
-public class WebMvcConfig extends WebMvcConfigurerAdapter {
-	@Bean
-	public WebMvcConfigurer corsConfigurer() {
-		return new WebMvcConfigurerAdapter() {
-			@Override
-			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("/**");
-			}
-		};
-	}
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*").allowedMethods("GET", "POST","PUT", "DELETE");
+    }
 	
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/src/main/java/gov/usgs/wma/mlrgateway/controller/GlobalDefaultExceptionHandler.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/controller/GlobalDefaultExceptionHandler.java
@@ -7,8 +7,9 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.tomcat.util.http.fileupload.FileUploadBase.FileSizeLimitExceededException;
-import org.apache.tomcat.util.http.fileupload.FileUploadBase.SizeLimitExceededException;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +55,8 @@ public class GlobalDefaultExceptionHandler {
 			}
 		} else if (ex instanceof MultipartException && 
 			(
-				((MultipartException)ex).getRootCause() instanceof FileSizeLimitExceededException || 
+				((MultipartException)ex).getRootCause() instanceof FileSizeLimitExceededException
+						|| 
 				((MultipartException)ex).getRootCause() instanceof SizeLimitExceededException
 			)
 		) {

--- a/src/main/java/gov/usgs/wma/mlrgateway/service/PreVerificationService.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/service/PreVerificationService.java
@@ -15,9 +15,6 @@ import com.netflix.hystrix.exception.HystrixBadRequestException;
 import gov.usgs.wma.mlrgateway.FeignBadResponseWrapper;
 import gov.usgs.wma.mlrgateway.client.DdotClient;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 @Service
 public class PreVerificationService {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,7 +84,7 @@ hystrix:
 logging:
   level:
     org:
-      springframework: ${mlrgateway_springFrameworkLogLevel:DEBUG}
+      springframework: ${mlrgateway_springFrameworkLogLevel:INFO}
 
 security:
   require-ssl: true

--- a/src/test/java/gov/usgs/wma/mlrgateway/controller/ExportWorkflowControllerTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/controller/ExportWorkflowControllerTest.java
@@ -2,9 +2,10 @@ package gov.usgs.wma.mlrgateway.controller;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -70,7 +71,6 @@ public class ExportWorkflowControllerTest extends BaseSpringTest {
 		ExportWorkflowController.setReport(new GatewayReport(ExportWorkflowController.COMPLETE_WORKFLOW, null, userName, reportDate));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void happyPath_ExportWorkflow() throws Exception {
 		when(authentication.getOAuth2Request()).thenReturn(mockOAuth2Request);
@@ -84,7 +84,7 @@ public class ExportWorkflowControllerTest extends BaseSpringTest {
 		assertEquals(rtn.getName(), ExportWorkflowController.COMPLETE_WORKFLOW);
 		
 		verify(export).exportWorkflow(anyString(), anyString());
-		verify(notificationService).sendNotification(anyList(), anyString(), anyString(), anyString(), anyObject());
+		verify(notificationService).sendNotification(anyList(), anyString(), eq(null), anyString(), any());
 	}
 
 	@Test

--- a/src/test/java/gov/usgs/wma/mlrgateway/controller/GlobalDefaultExceptionHandlerTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/controller/GlobalDefaultExceptionHandlerTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -70,7 +71,7 @@ public class GlobalDefaultExceptionHandlerTest {
 	public void handleHttpMessageNotReadableException() throws IOException {
 		HttpServletResponse response = new MockHttpServletResponse();
 		String expected = "Some123$Mes\tsage!!.";
-		Map<String, String> actual = controller.handleUncaughtException(new HttpMessageNotReadableException(expected), request, response);
+		Map<String, String> actual = controller.handleUncaughtException(new HttpMessageNotReadableException(expected, new MockHttpInputMessage("test".getBytes())), request, response);
 		assertEquals(expected, actual.get(GlobalDefaultExceptionHandler.ERROR_MESSAGE_KEY));
 		assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
 	}
@@ -79,7 +80,7 @@ public class GlobalDefaultExceptionHandlerTest {
 	public void handleMultilineHttpMessageNotReadableException() throws IOException {
 		HttpServletResponse response = new MockHttpServletResponse();
 		String expected = "ok to see";
-		Map<String, String> actual = controller.handleUncaughtException(new HttpMessageNotReadableException("ok to see\nhide this\nand this"), request, response);
+		Map<String, String> actual = controller.handleUncaughtException(new HttpMessageNotReadableException("ok to see\nhide this\nand this", new MockHttpInputMessage("test".getBytes())), request, response);
 		assertEquals(expected, actual.get(GlobalDefaultExceptionHandler.ERROR_MESSAGE_KEY));
 		assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
 	}	

--- a/src/test/java/gov/usgs/wma/mlrgateway/controller/UtilControllerTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/controller/UtilControllerTest.java
@@ -60,9 +60,7 @@ public class UtilControllerTest extends BaseSpringTest {
 		String badText = "This is really bad.";
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
 		willThrow(new FeignBadResponseWrapper(500, null, badText)).given(preVerificationService).parseDdot(any(MultipartFile.class));
-
-		Map<String, Set<String>> rtn = controller.parseWorkflow(file, response);
-		
+		controller.parseWorkflow(file, response);
 		verify(preVerificationService).parseDdot(any(MultipartFile.class));
 	}
 

--- a/src/test/java/gov/usgs/wma/mlrgateway/service/LegacyTransformerServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/service/LegacyTransformerServiceTest.java
@@ -95,7 +95,7 @@ public class LegacyTransformerServiceTest extends BaseSpringTest {
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
 
 		try {
-			Map<String, Object> rtn = service.transformGeo(addGeo(getAdd()), siteReport);
+			service.transformGeo(addGeo(getAdd()), siteReport);
 			fail("transformGeo did not throw an error");
 		} catch(FeignBadResponseWrapper e) {}
 		
@@ -137,7 +137,7 @@ public class LegacyTransformerServiceTest extends BaseSpringTest {
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
 		
 		try {
-			Map<String, Object> rtn = service.transformStationIx(addIX(getAdd()), siteReport);
+			service.transformStationIx(addIX(getAdd()), siteReport);
 			fail("transformStationIx did not throw an error");
 		} catch(FeignBadResponseWrapper e) {}
 		

--- a/src/test/java/gov/usgs/wma/mlrgateway/service/LegacyValidatorServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/service/LegacyValidatorServiceTest.java
@@ -3,7 +3,6 @@ package gov.usgs.wma.mlrgateway.service;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyObject;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +18,6 @@ import gov.usgs.wma.mlrgateway.SiteReport;
 import gov.usgs.wma.mlrgateway.client.LegacyValidatorClient;
 import gov.usgs.wma.mlrgateway.controller.BaseController;
 import gov.usgs.wma.mlrgateway.controller.WorkflowController;
-import gov.usgs.wma.mlrgateway.service.LegacyCruService;
 
 import java.util.Map;
 import static org.junit.Assert.assertEquals;
@@ -55,13 +53,14 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 	}
 
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void validatorService_doValidation_addValidData() throws Exception {
 		Map<String, Object> ml = getAdd();
 		String responseMsg = "{\"validation_passed_message\": \"Validation passed.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		Map<String, Object> mlValid = service.doValidation(ml, true, siteReport);
@@ -79,13 +78,14 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 	}
 	
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void validatorService_doValidation_updateValidData() throws Exception {
 		Map<String, Object> ml = getAdd();
 		String responseMsg = "{\"validation_passed_message\": \"Validation passed.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateUpdate(anyString())).willReturn(validatorResponse);
 		
 		Map<String, Object> mlValid = service.doValidation(ml, false, siteReport);
@@ -103,13 +103,14 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 	}
 	
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void validatorService_doValidation_nonExisting() throws Exception {
 		Map<String, Object> ml = getAdd();
 		String responseMsg = "{\"validation_passed_message\": \"Validation passed.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		Map<String, Object> mlValid = service.doValidation(ml, true, siteReport);
@@ -128,13 +129,14 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 	}
 	
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void validatorService_doValidation_addWarningData() throws Exception {
 		Map<String, Object> ml = getAdd();
 		String responseMsg = "{\"validation_passed_message\": \"Validation passed.\", \"warning_message\": \"Warnings.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		Map<String, Object> mlValid = service.doValidation(ml, true, siteReport);
@@ -153,13 +155,14 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 	}
 	
 	@Test
+	@SuppressWarnings("rawtypes")
 	public void validatorService_doValidation_updateWarningData() throws Exception {
 		Map<String, Object> ml = getAdd();
 		String responseMsg = "{\"validation_passed_message\": \"Validation passed.\", \"warning_message\": \"Warnings.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateUpdate(anyString())).willReturn(validatorResponse);
 		
 		Map<String, Object> mlValid = service.doValidation(ml, false, siteReport);
@@ -184,8 +187,8 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		String responseMsg = "{\"fatal_error_message\": \"Fatal Error.\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		try{
@@ -215,8 +218,8 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		String responseMsg = "{}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		try{
@@ -244,8 +247,8 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		String responseMsg = "{\"invalid_key\":\"some data\"}";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		try{
@@ -273,8 +276,8 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		String responseMsg = "Bad Request";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.BAD_REQUEST);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		try{
@@ -302,8 +305,8 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		String responseMsg = "I'm Not JSON";
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
-		given(legacyCruService.validateMonitoringLocation(any(), anyObject())).willReturn("{}");
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("{}");
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
 		
 		try{
@@ -332,9 +335,9 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
 		
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
-		given(legacyCruService.validateMonitoringLocation(anyObject(), anyObject())).willReturn("Error");
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("Error");
 
 		try{
 			service.doValidation(ml, true, siteReport);
@@ -363,9 +366,9 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
 		
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
-		given(legacyCruService.validateMonitoringLocation(anyObject(), anyObject())).willThrow(new RuntimeException("error"));
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willThrow(new RuntimeException("error"));
 
 		try{
 			service.doValidation(ml, true, siteReport);
@@ -394,9 +397,9 @@ public class LegacyValidatorServiceTest extends BaseSpringTest {
 		ResponseEntity<String> validatorResponse = new ResponseEntity<> (responseMsg, HttpStatus.OK);
 		SiteReport siteReport = new SiteReport(agencyCode, siteNumber);
 		
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(ml);
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(ml);
 		given(legacyValidatorClient.validateAdd(anyString())).willReturn(validatorResponse);
-		given(legacyCruService.validateMonitoringLocation(anyObject(), anyObject())).willReturn("Error");
+		given(legacyCruService.validateMonitoringLocation(any(), any())).willReturn("Error");
 
 		try{
 			service.doValidation(ml, true, siteReport);

--- a/src/test/java/gov/usgs/wma/mlrgateway/service/NotificationServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/service/NotificationServiceTest.java
@@ -23,7 +23,6 @@ import gov.usgs.wma.mlrgateway.UserSummaryReport;
 import gov.usgs.wma.mlrgateway.client.NotificationClient;
 import gov.usgs.wma.mlrgateway.controller.BaseController;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/test/java/gov/usgs/wma/mlrgateway/workflow/ExportWorkflowServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/workflow/ExportWorkflowServiceTest.java
@@ -1,10 +1,9 @@
 package gov.usgs.wma.mlrgateway.workflow;
 
-import gov.usgs.wma.mlrgateway.workflow.ExportWorkflowService;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
@@ -47,22 +46,22 @@ public class ExportWorkflowServiceTest extends BaseSpringTest {
 		Map<String,Object> site;
 		site = getAdd();
 		
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(site);
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(site);
 
 		service.exportWorkflow("USGS", "12345678");
 		
-		verify(legacyCruService).getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject());
-		verify(fileExportService).exportAdd(anyString(), anyString(), anyString(), anyObject());
+		verify(legacyCruService).getMonitoringLocation(anyString(), anyString(), anyBoolean(), any());
+		verify(fileExportService).exportAdd(anyString(), anyString(), anyString(), any());
 	}
 	
 	@Test
 	public void completeWorkflow_siteDoesNotExist() throws Exception {
-		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject())).willReturn(new HashMap<>());
+		given(legacyCruService.getMonitoringLocation(anyString(), anyString(), anyBoolean(), any())).willReturn(new HashMap<>());
 		
 		service.exportWorkflow("USGS", "1234");
 		
-		verify(legacyCruService).getMonitoringLocation(anyString(), anyString(), anyBoolean(), anyObject());
-		verify(fileExportService, never()).exportAdd(anyString(), anyString(), anyString(), anyObject());
+		verify(legacyCruService).getMonitoringLocation(anyString(), anyString(), anyBoolean(), any());
+		verify(fileExportService, never()).exportAdd(anyString(), anyString(), anyString(), any());
 	}
 
 }

--- a/src/test/java/gov/usgs/wma/mlrgateway/workflow/LegacyWorkflowServiceTest.java
+++ b/src/test/java/gov/usgs/wma/mlrgateway/workflow/LegacyWorkflowServiceTest.java
@@ -1,6 +1,5 @@
 package gov.usgs.wma.mlrgateway.workflow;
 
-import gov.usgs.wma.mlrgateway.workflow.LegacyWorkflowService;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -8,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,7 +65,6 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		WorkflowController.setReport(new GatewayReport(reportName, fileName, userName, reportDate));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void noTransactionType_completeWorkflow_thenReturnBadRequest() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
@@ -79,13 +76,13 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		GatewayReport rtn = WorkflowController.getReport();
 		
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService, never()).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService, never()).doValidation(anyMap(), anyBoolean(), anyObject());
-		verify(transformService, never()).transformGeo(anyMap(), anyObject());
-		verify(legacyCruService, never()).addTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(legacyCruService, never()).updateTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService, never()).exportAdd(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService, never()).exportUpdate(anyString(), anyString(), anyString(), anyObject());
+		verify(transformService, never()).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService, never()).doValidation(anyMap(), anyBoolean(), any());
+		verify(transformService, never()).transformGeo(anyMap(), any());
+		verify(legacyCruService, never()).addTransaction(anyString(), anyString(), anyString(), any());
+		verify(legacyCruService, never()).updateTransaction(anyString(), anyString(), anyString(), any());
+		verify(fileExportService, never()).exportAdd(anyString(), anyString(), anyString(), any());
+		verify(fileExportService, never()).exportUpdate(anyString(), anyString(), anyString(), any());
 		assertEquals(rtn.getSites().get(0).isSuccess(), false);
 		assertEquals(rtn.getSites().get(0).getSteps().get(0).isSuccess(), false);
 		assertNull(rtn.getSites().get(0).getTransactionType());
@@ -93,7 +90,6 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		assertEquals(rtn.getSites().get(0).getSteps().get(0).getDetails(), "{\"error_message\": \"Validation failed due to a missing transaction type.\"}");
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void noTransactionType_completeWorkflow_noStopOnError() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
@@ -101,28 +97,27 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		Map<String, Object> ml = getAdd();
 
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(ddotRtn);
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(ml);
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willReturn(getAddValid());
-		given(transformService.transformGeo(anyMap(), anyObject())).willReturn(getAddValid());
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(ml);
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willReturn(getAddValid());
+		given(transformService.transformGeo(anyMap(), any())).willReturn(getAddValid());
 
 		service.completeWorkflow(file);
 		
 		GatewayReport rtn = WorkflowController.getReport();
 
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), anyObject());
-		verify(transformService).transformGeo(anyMap(), anyObject());
-		verify(legacyCruService).addTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(legacyCruService, never()).updateTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService).exportAdd(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService, never()).exportUpdate(anyString(), anyString(), anyString(), anyObject());
+		verify(transformService).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), any());
+		verify(transformService).transformGeo(anyMap(), any());
+		verify(legacyCruService).addTransaction(anyString(), anyString(), anyString(), any());
+		verify(legacyCruService, never()).updateTransaction(anyString(), anyString(), anyString(), any());
+		verify(fileExportService).exportAdd(anyString(), anyString(), eq(null), any());
+		verify(fileExportService, never()).exportUpdate(anyString(), anyString(), anyString(), any());
 		assertFalse(rtn.getSites().get(0).isSuccess());
 		assertFalse(rtn.getSites().get(0).getSteps().get(0).isSuccess());
 		assertEquals(rtn.getSites().get(0).getSteps().get(0).getHttpStatus().toString(), "400");
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void oneAddTransaction_completeWorkflow_thenReturnCreated() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
@@ -133,25 +128,24 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 
 		
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(ddotRtn);
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(ml);
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willReturn(mlValid);
-		given(transformService.transformGeo(anyMap(), anyObject())).willReturn(mlValid);
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(ml);
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willReturn(mlValid);
+		given(transformService.transformGeo(anyMap(), any())).willReturn(mlValid);
 		
 		service.completeWorkflow(file);
 		
 		GatewayReport rtn = WorkflowController.getReport();
 		
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), anyObject());
-		verify(transformService).transformGeo(anyMap(), anyObject());
-		verify(legacyCruService).addTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService).exportAdd(anyString(), anyString(), anyString(), anyObject());
+		verify(transformService).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), any());
+		verify(transformService).transformGeo(anyMap(), any());
+		verify(legacyCruService).addTransaction(anyString(), anyString(), anyString(), any());
+		verify(fileExportService).exportAdd(anyString(), anyString(), eq(null), any());
 		assertTrue(rtn.getSites().get(0).isSuccess());
 		assertEquals(rtn.getSites().get(0).getTransactionType(), LegacyWorkflowService.TRANSACTION_TYPE_ADD);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void oneUpdateTransaction_completeWorkflow_thenReturnUpdated() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
@@ -162,24 +156,23 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 
 		
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(ddotRtn);
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(ml);
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willReturn(mlValid);
-		given(transformService.transformGeo(anyMap(), anyObject())).willReturn(mlValid);
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(ml);
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willReturn(mlValid);
+		given(transformService.transformGeo(anyMap(), any())).willReturn(mlValid);
 
 		service.completeWorkflow(file);
 		GatewayReport rtn = WorkflowController.getReport();
 		
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), anyObject());
-		verify(transformService).transformGeo(anyMap(), anyObject());
-		verify(legacyCruService).updateTransaction(anyString(), anyString(), anyString(), anyObject());
-		verify(fileExportService).exportUpdate(anyString(), anyString(), anyString(), anyObject());
+		verify(transformService).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), any());
+		verify(transformService).transformGeo(anyMap(), any());
+		verify(legacyCruService).updateTransaction(anyString(), anyString(), anyString(), any());
+		verify(fileExportService).exportUpdate(anyString(), anyString(), eq(null), any());
 		assertTrue(rtn.getSites().get(0).isSuccess());
 		assertEquals(rtn.getSites().get(0).getTransactionType(), LegacyWorkflowService.TRANSACTION_TYPE_UPDATE);
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Test
 	public void ddotAddValidation_callsCorrectBackingServices() throws Exception {
 		
@@ -188,21 +181,20 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
 
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(DdotServiceTest.singleAdd());
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(ml);
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willReturn(mlValid);
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(ml);
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willReturn(mlValid);
 		
 		service.ddotValidation(file);
 		
 		GatewayReport rtn = WorkflowController.getReport();
 		
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService).doValidation(anyMap(), eq(true), anyObject());
-		verify(legacyValidatorService, never()).doValidation(anyMap(), eq(false), anyObject());
+		verify(transformService).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService).doValidation(anyMap(), eq(true), any());
+		verify(legacyValidatorService, never()).doValidation(anyMap(), eq(false), any());
 		assertTrue(rtn.getSites().get(0).isSuccess());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void ddotUpdateValidation_callsCorrectBackingServices() throws Exception {
 		Map<String, Object> ml = getUpdate();
@@ -210,27 +202,26 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
 
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(DdotServiceTest.singleUpdate());
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(ml);
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willReturn(mlValid);
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(ml);
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willReturn(mlValid);
 		
 		service.ddotValidation(file);
 		GatewayReport rtn = WorkflowController.getReport();
 
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(transformService).transformStationIx(anyMap(), anyObject());
-		verify(legacyValidatorService).doValidation(anyMap(), eq(false), anyObject());
-		verify(legacyValidatorService, never()).doValidation(anyMap(), eq(true), anyObject());
+		verify(transformService).transformStationIx(anyMap(), any());
+		verify(legacyValidatorService).doValidation(anyMap(), eq(false), any());
+		verify(legacyValidatorService, never()).doValidation(anyMap(), eq(true), any());
 		assertTrue(rtn.getSites().get(0).isSuccess());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void ddotValidation_throwsException() throws Exception {
 		MockMultipartFile file = new MockMultipartFile("file", "d.", "text/plain", "".getBytes());
 
 		given(ddotService.parseDdot(any(MultipartFile.class))).willReturn(DdotServiceTest.singleAdd());
-		given(transformService.transformStationIx(anyMap(), anyObject())).willReturn(getAdd());
-		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), anyObject())).willThrow(new RuntimeException());
+		given(transformService.transformStationIx(anyMap(), any())).willReturn(getAdd());
+		given(legacyValidatorService.doValidation(anyMap(), anyBoolean(), any())).willThrow(new RuntimeException());
 
 		service.ddotValidation(file);
 
@@ -243,6 +234,6 @@ public class LegacyWorkflowServiceTest extends BaseSpringTest {
 		assertEquals(rtn.getSites().get(0).getSteps().get(0).getDetails(), "{\"error_message\": \"null\"}");
 		assertEquals(rtn.getSites().get(0).getSteps().get(0).getName(), LegacyWorkflowService.VALIDATE_DDOT_TRANSACTION_STEP);
 		verify(ddotService).parseDdot(any(MultipartFile.class));
-		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), anyObject());
+		verify(legacyValidatorService).doValidation(anyMap(), anyBoolean(), any());
 	}
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,75 +1,32 @@
-server:
-  port: ${serverPort:8443}
-  use-forward-headers: true
-  session:
-    timeout: ${sessionTimeout:43200}
-  ssl:
-    key-store: ${keystoreLocation}
-    key-store-password: ${keystorePassword}
-    key-password: ${keystorePassword}
-    key-alias: ${keystoreSSLKey:tomcat}
-    enabled-protocols: TLSv1.2
-
-additionalNotificationRecipients: ${mlrgateway_additionalNotificationRecipients:}
-
-
-zuul:
-  retryable: true
-  ribbonIsolationStrategy: SEMAPHORE
-  routes:
-    legacyCruBase:
-      path: /monitoringLocations**
-      serviceId: legacyCru
-      stripPrefix: false
-    legacyCruPlus:
-      path: /monitoringLocations/**
-      serviceId: legacyCru
-      stripPrefix: false
-
 ddot:
   ribbon:
-    listOfServers: ${mlrgateway_ddotServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_ddotIsSecure:true}
+    listOfServers: https://test.gov/test
 
 legacyTransformer:
   ribbon:
-    listOfServers: ${mlrgateway_legacyTransformerServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_legacyTransformerIsSecure:true}
+    listOfServers: https://test.gov/test
 
 legacyValidator:
   ribbon:
-    listOfServers: ${mlrgateway_legacyValidatorServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_legacyValidatorIsSecure:true}
+    listOfServers: https://test.gov/test
 
 legacyCru:
   ribbon:
-    listOfServers: ${mlrgateway_legacyCruServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_legacyCruIsSecure:true}
+    listOfServers: https://test.gov/test
 
 fileExport:
   ribbon:
-    listOfServers: ${mlrgateway_fileExportServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_fileExportIsSecure:true}
+    listOfServers: https://test.gov/test
 
 notification:
   ribbon:
-    listOfServers: ${mlrgateway_notificationServers:https://test.gov/test}
-    IsSecure: ${mlrgateway_notificationIsSecure:true}
-
-eureka:
-  client:
-    enabled: false
-
-feign:
-  hystrix:
-    enabled: true
+    listOfServers: https://test.gov/test
 
 ribbon:
   MaxAutoRetries: 1
   MaxAutoRetriesNextServer: 0
   ConnectTimeout: 99999
   ReadTimeout: 99999
-  OkToRetryOnAllOperations: true
 
 hystrix:
   shareSecurityContext: true
@@ -81,15 +38,7 @@ hystrix:
           thread:
             timeoutInMilliseconds: 99999
 
-logging:
-  level:
-    org:
-      springframework: ${mlrgateway_springFrameworkLogLevel:DEBUG}
-
 security:
-  require-ssl: true
-  basic:
-    enabled: false
   maintenanceRoles: test_allowed
   oauth2:
     client:
@@ -102,3 +51,4 @@ security:
       jwt:
         keyValue: secret
 oauthResourceTokenKeyUri: 
+additionalNotificationRecipients: 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,32 +28,32 @@ zuul:
 
 ddot:
   ribbon:
-    listOfServers: ${mlrgateway_ddotServers}
+    listOfServers: ${mlrgateway_ddotServers:https://test.gov/test}
     IsSecure: ${mlrgateway_ddotIsSecure:true}
 
 legacyTransformer:
   ribbon:
-    listOfServers: ${mlrgateway_legacyTransformerServers}
+    listOfServers: ${mlrgateway_legacyTransformerServers:https://test.gov/test}
     IsSecure: ${mlrgateway_legacyTransformerIsSecure:true}
 
 legacyValidator:
   ribbon:
-    listOfServers: ${mlrgateway_legacyValidatorServers}
+    listOfServers: ${mlrgateway_legacyValidatorServers:https://test.gov/test}
     IsSecure: ${mlrgateway_legacyValidatorIsSecure:true}
 
 legacyCru:
   ribbon:
-    listOfServers: ${mlrgateway_legacyCruServers}
+    listOfServers: ${mlrgateway_legacyCruServers:https://test.gov/test}
     IsSecure: ${mlrgateway_legacyCruIsSecure:true}
 
 fileExport:
   ribbon:
-    listOfServers: ${mlrgateway_fileExportServers}
+    listOfServers: ${mlrgateway_fileExportServers:https://test.gov/test}
     IsSecure: ${mlrgateway_fileExportIsSecure:true}
 
 notification:
   ribbon:
-    listOfServers: ${mlrgateway_notificationServers}
+    listOfServers: ${mlrgateway_notificationServers:https://test.gov/test}
     IsSecure: ${mlrgateway_notificationIsSecure:true}
 
 eureka:
@@ -65,10 +65,10 @@ feign:
     enabled: true
 
 ribbon:
-  MaxAutoRetries: ${mlrgateway_ribbonMaxAutoRetries}
+  MaxAutoRetries: 1
   MaxAutoRetriesNextServer: 0
-  ConnectTimeout: ${mlrgateway_ribbonConnectTimeout}
-  ReadTimeout: ${mlrgateway_ribbonReadTimeout}
+  ConnectTimeout: 99999
+  ReadTimeout: 99999
   OkToRetryOnAllOperations: true
 
 hystrix:
@@ -79,7 +79,7 @@ hystrix:
         isolation:
           strategy: SEMAPHORE
           thread:
-            timeoutInMilliseconds: ${mlrgateway_hystrixThreadTimeout}
+            timeoutInMilliseconds: 99999
 
 logging:
   level:
@@ -90,14 +90,15 @@ security:
   require-ssl: true
   basic:
     enabled: false
+  maintenanceRoles: test_allowed
   oauth2:
     client:
-      clientId: ${oauthClientId}
-      clientSecret: ${oauthClientSecret}
-      accessTokenUri: ${oauthClientAccessTokenUri}
-      userAuthorizationUri: ${oauthClientAuthorizationUri}
+      clientId: test-client
+      clientSecret: test-secret
+      accessTokenUri: localhost
+      userAuthorizationUri: localhost
     resource:
-      id: ${oauthResourceId}
+      id: test-app
       jwt:
-        keyUri: ${oauthResourceTokenKeyUri}
-  maintenanceRoles: ${maintenanceRoles:}
+        keyValue: secret
+oauthResourceTokenKeyUri: 


### PR DESCRIPTION
…. Did not update to JUnit5. Minor cleanup.

Skipped updates to Spring Security and JUnit 5 because while WaterAuth can handle _Resource Server_ clients on Spring Security 5.1, it cannot handle _Authorization Server_ clients because currently the Spring Security 5.1 Authorization Server implementation does not support JWTs as a token format from an IDP Server, which Water Auth serves as in this case.