### PR TITLE
Enable configurable session timeout for Spring Session…

### DIFF
--- a/src/main/java/gov/usgs/wma/mlrgateway/config/WebSecurityConfig.java
+++ b/src/main/java/gov/usgs/wma/mlrgateway/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package gov.usgs.wma.mlrgateway.config;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -15,6 +16,9 @@ import org.springframework.session.web.http.HttpSessionIdResolver;
 @EnableSpringHttpSession
 @Configuration
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	@Value("${server.session.timeout:}")
+	private Integer sessionTimeoutSeconds;
 	
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
@@ -42,7 +46,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	public MapSessionRepository sessionRepository() {
-		return new MapSessionRepository(new ConcurrentHashMap<>());
+		MapSessionRepository sessionRepo = new MapSessionRepository(new ConcurrentHashMap<>());
+		sessionRepo.setDefaultMaxInactiveInterval(sessionTimeoutSeconds);
+		return sessionRepo;
 	}
 
 	@Bean


### PR DESCRIPTION
…MapSessionRepository.

Turns out when using Spring Session and the MapSessionRepository the default spring way of overriding session timeout which we had setup before (`spring.session.timeout` config parameter) is not used, it has to be manually set on the MapSessionRepository instance. When not set the default is 30 minutes which is longer than I had my session sit when testing locally and was resulting in the login timeouts Joe was still seeing on Test.